### PR TITLE
Spaces at the end of Values Arrays are ignored

### DIFF
--- a/src/parser/ParserProbModelXML.cpp
+++ b/src/parser/ParserProbModelXML.cpp
@@ -1122,6 +1122,7 @@ const vector<double>* ParserProbModelXML::ParseArray(const xmlNodePtr node)
       {
         data >> skipws >> d;
         p->push_back(d);
+        ws(data);
       }
       
       _m_arrayCache[node] = p;


### PR DESCRIPTION
Fixes an issue in which the last value of a `<Values>...</Values>` tag would be added to the vector twice if the contents of the Value tag ended in whitespace. This resulted in a `std::out_of_range` exception later down the line when these vectors moved to for instance the ISD vectors that are allocated the proper size for the states.