### PR TITLE
Added export policy functionality

### DIFF
--- a/src/planning/argumentHandlers.cpp
+++ b/src/planning/argumentHandlers.cpp
@@ -168,7 +168,7 @@ extern const struct argp_child problemFile_child = {&problemFile_argp, 0, "Probl
 
 
 //global options (globalOptions)
-static const int GID_GLOBALOPTIONS=8;
+static const int GID_GLOBALOPTIONS=9;
 const char *globalOptions_argp_version = "global options parser 0.1";
 static const char *globalOptions_args_doc = 0;
 static const char *globalOptions_doc = 
@@ -226,6 +226,7 @@ not be shown)";
 /* Keys for options without short-options. */
 static const int OPT_PREFIX=1;
 static const int OPT_NORECOMPUTE=2;
+static const int OPT_OUTPUT_POLICY=3;
 static struct argp_option outputFileOptions_options[] = {
 {"dry-run",  'd', 0,       0, "Do not actually create any output files." },
 {"description",  'D', "DESCR",       0, 
@@ -234,6 +235,7 @@ in the output file's names." },
 {"prefix",    OPT_PREFIX, "PREFIX",      0, 
 "Use PREFIX as a prefix for the output result files." },
 {"dontReCompute",  OPT_NORECOMPUTE, 0,       0, "Check if the output file already exists, if so don't re-compute the result, but exit immediately." },
+{"outputPolicy", OPT_OUTPUT_POLICY, 0, 0, "Output the individual policies to a file"},
 { 0 }
 };
 error_t
@@ -256,6 +258,9 @@ outputFileOptions_parse_argument (int key, char *arg, struct argp_state *state)
             break;
         case OPT_NORECOMPUTE:
             theArgumentsStruc->noReCompute = 1;
+            break;
+        case OPT_OUTPUT_POLICY:
+            theArgumentsStruc->outputPolicy = true;
             break;
         default:
             return ARGP_ERR_UNKNOWN;

--- a/src/planning/argumentHandlers.h
+++ b/src/planning/argumentHandlers.h
@@ -71,6 +71,7 @@ struct Arguments
     int dryrun;
     char * description, * prefix;
     int noReCompute;
+    bool outputPolicy;
 
     //model options (modelOptions)
     bool cache_flat_models;
@@ -223,6 +224,7 @@ struct Arguments
         description = NULL;
         prefix = NULL;
         noReCompute = 0;
+        outputPolicy = false;
 
         // model
         cache_flat_models = false;

--- a/src/solvers/BFS.cpp
+++ b/src/solvers/BFS.cpp
@@ -9,6 +9,7 @@
  *
  * Frans Oliehoek 
  * Matthijs Spaan 
+ * Robert Hand
  *
  * For contact information please see the included AUTHORS file.
  */
@@ -113,6 +114,12 @@ int main(int argc, char **argv)
             of.flush();
         }
     }
+
+    if(!args.dryrun && args.outputPolicy)
+    {
+        string outputFileName = filename + "_PolicyFile";
+        bfs.GetJointPolicyPureVector()->ExportPolicyToFile(outputFileName, bfs.GetHorizon());
     }
-    catch(E& e){ e.Print(); }
+
+    } catch(E& e){ e.Print(); }
 }

--- a/src/support/JPolComponent_VectorImplementation.cpp
+++ b/src/support/JPolComponent_VectorImplementation.cpp
@@ -7,14 +7,18 @@
  *
  * This file has been written and/or modified by the following people:
  *
- * Frans Oliehoek 
- * Matthijs Spaan 
+ * Frans Oliehoek
+ * Matthijs Spaan
+ * Robert Hand
  *
  * For contact information please see the included AUTHORS file.
  */
 
 #include "JPolComponent_VectorImplementation.h"
 #include "IndexTools.h"
+
+#include <fstream>
+
 using namespace std;
 
 
@@ -464,7 +468,7 @@ string JPolComponent_VectorImplementation::SoftPrint(void) const
            << _m_indivPols_PolicyPureVector.at(agentI)->SoftPrint();
     }
     return(ss.str());
-} 
+}
 
 string JPolComponent_VectorImplementation::SoftPrintBrief(void) const
 {
@@ -477,3 +481,46 @@ string JPolComponent_VectorImplementation::SoftPrintBrief(void) const
     return(ss.str());
 }
         
+void JPolComponent_VectorImplementation::ExportPolicyToFile(const std::string& path, const Index& horizon) const {
+    ofstream fp(path.c_str());
+
+    // Output horizon
+    fp << "Horizon : " << horizon << endl;
+
+    // Get nr agents and output to file
+    Index nrAgents = GetInterfacePTPDiscretePure()->GetNrAgents();
+    fp << "NrAgents : " << nrAgents << endl;
+
+
+    vector<Index> numObvsHistory(nrAgents);
+
+    // Get number of observation histories for each agent
+    for(Index i=0; i<nrAgents; ++i) {
+
+        numObvsHistory[i] = GetInterfacePTPDiscretePure()->GetNrPolicyDomainElements(
+            i, PolicyGlobals::OHIST_INDEX, _m_indivPols_PolicyPureVector[i]->GetDepth());
+
+        fp << i << " : " << numObvsHistory[i] << endl;
+    }
+
+    // Output policies for all agents
+    for(Index i=0; i<nrAgents; ++i) {
+
+        // Output policy
+        fp << endl << endl;
+
+        // Output first action
+        fp << _m_indivPols_PolicyPureVector[i]->GetActionIndex(0) << " ";
+
+        // Output rest
+        for(Index j=1; j<numObvsHistory[i]; ++j) {
+
+            // Break lines
+            if(j % 30 == 0) {
+                fp << endl;
+            }
+
+            fp << _m_indivPols_PolicyPureVector[i]->GetActionIndex(j) << " ";
+        }
+    }
+}

--- a/src/support/JPolComponent_VectorImplementation.h
+++ b/src/support/JPolComponent_VectorImplementation.h
@@ -7,8 +7,9 @@
  *
  * This file has been written and/or modified by the following people:
  *
- * Frans Oliehoek 
- * Matthijs Spaan 
+ * Frans Oliehoek
+ * Matthijs Spaan
+ * Robert Hand
  *
  * For contact information please see the included AUTHORS file.
  */
@@ -143,6 +144,13 @@ class JPolComponent_VectorImplementation
         /// Prints a description of this to a string.
         std::string SoftPrint() const; 
         std::string SoftPrintBrief() const;
+
+        /// Export the policy to a file of individual policies
+        /** Exports the policy to a file at the given path as
+         *  individual policies expressed as the actions for each
+         *  individual oh index.
+         */
+        void ExportPolicyToFile(const std::string& path, const Index& horizon) const;
 
         
         ///Returns the jaI taken by this policy for joint domain index johI.

--- a/src/support/JointPolicyPureVector.h
+++ b/src/support/JointPolicyPureVector.h
@@ -7,8 +7,9 @@
  *
  * This file has been written and/or modified by the following people:
  *
- * Frans Oliehoek 
- * Matthijs Spaan 
+ * Frans Oliehoek
+ * Matthijs Spaan
+ * Robert Hand
  *
  * For contact information please see the included AUTHORS file.
  */
@@ -172,7 +173,15 @@ class JointPolicyPureVector  :
         std::string SoftPrintBrief() const; 
         void PrintBrief() const
         { std::cout << SoftPrintBrief();}
-        
+
+        /// Export the policy to a file of individual policies
+        /** Exports the policy to a file at the given path as
+         *  individual policies expressed as the actions for each
+         *  individual oh index.
+         */
+        void ExportPolicyToFile(const std::string &path, const Index &horizon) const
+        { this->JPolComponent_VectorImplementation::ExportPolicyToFile(path, horizon); };
+
         /**\brief Convert this joint policy to a JointPolicyPureVector.
          */
         JPPV_sharedPtr ToJointPolicyPureVector() const;


### PR DESCRIPTION
This adds functionality to export the policy to a file for use with [MADP-TreeVis](https://github.com/roberthand9/MADP-TreeVis) - Completed as part of a Final Year Project at the University of Liverpool.

Format of the file is the horizon, number of agents the policy is for, number of observation histories for each agent, and the individual policies themselves as the action indexes for the observation history indexes.

Outputting the policy to a file is achieved using the `--outputPolicy` switch. An example of how to call the function is in the `BFS.cpp` file.

Feedback is welcome, I will try my best to make any necessary changes!