### PR TITLE
Fix potential compilation error

### DIFF
--- a/src/libDAI/prob.h
+++ b/src/libDAI/prob.h
@@ -528,7 +528,7 @@ namespace libDAI {
             bool hasNaNs() const {
                 bool NaNs = false;
                 for( size_t i = 0; i < size() && !NaNs; i++ ) 
-                    if( isnan( _p[i] ) )
+                    if( std::isnan( _p[i] ) )
                         NaNs = true;
                 return NaNs;
             }


### PR DESCRIPTION
Compilation was crashing with "unknown reference to isnan".
Adding `std::` avoids this error.

Note: this updates a third party library (libDAI), so not sure if you want to accept this - but might be helpful for someone experiencing this compilation issue in either case.